### PR TITLE
Merge branch '2.8' into 3.2

### DIFF
--- a/Tests/HttpUtilsTest.php
+++ b/Tests/HttpUtilsTest.php
@@ -38,6 +38,38 @@ class HttpUtilsTest extends TestCase
         $this->assertTrue($response->isRedirect('http://symfony.com/'));
     }
 
+    public function testCreateRedirectResponseWithDomainRegexp()
+    {
+        $utils = new HttpUtils($this->getUrlGenerator(), null, '#^https?://symfony\.com$#i');
+        $response = $utils->createRedirectResponse($this->getRequest(), 'http://symfony.com/blog');
+
+        $this->assertTrue($response->isRedirect('http://symfony.com/blog'));
+    }
+
+    public function testCreateRedirectResponseWithRequestsDomain()
+    {
+        $utils = new HttpUtils($this->getUrlGenerator(), null, '#^https?://%s$#i');
+        $response = $utils->createRedirectResponse($this->getRequest(), 'http://localhost/blog');
+
+        $this->assertTrue($response->isRedirect('http://localhost/blog'));
+    }
+
+    public function testCreateRedirectResponseWithBadRequestsDomain()
+    {
+        $utils = new HttpUtils($this->getUrlGenerator(), null, '#^https?://%s$#i');
+        $response = $utils->createRedirectResponse($this->getRequest(), 'http://pirate.net/foo');
+
+        $this->assertTrue($response->isRedirect('http://localhost/'));
+    }
+
+    public function testCreateRedirectResponseWithProtocolRelativeTarget()
+    {
+        $utils = new HttpUtils($this->getUrlGenerator(), null, '#^https?://%s$#i');
+        $response = $utils->createRedirectResponse($this->getRequest(), '//evil.com/do-bad-things');
+
+        $this->assertTrue($response->isRedirect('http://localhost//evil.com/do-bad-things'), 'Protocol-relative redirection should not be supported for security reasons');
+    }
+
     public function testCreateRedirectResponseWithRouteName()
     {
         $utils = new HttpUtils($urlGenerator = $this->getMockBuilder('Symfony\Component\Routing\Generator\UrlGeneratorInterface')->getMock());


### PR DESCRIPTION
* 2.8:
  fixed CS
  [2.8] Modify 2.8 upgrade doc - key option is deprecated.
  [DebugBundle] Reword an outdated comment about var dumper wiring
  [DI] Fix some docblocks
  Ignore memcached missing key error on dession destroy
  Github template: Remove EOM 3.2 from branch suggestion
  [Security] Fix security.interactive_login event const doc block
  Avoid infinite loops when profiler data is malformed
  [Bridge\ProxyManager] Dont call __destruct() on non-instantiated services
  Docblock improvement
  bumped Symfony version to 2.8.27
  updated VERSION for 2.8.26
  updated CHANGELOG for 2.8.26
  bumped Symfony version to 2.7.34
  updated VERSION for 2.7.33
  update CONTRIBUTORS for 2.7.33
  updated CHANGELOG for 2.7.33
  [HttpFoundation] Generate safe fallback filename for wrongly encoded filename