### PR TITLE
fixed user refresh on stop impersonating

### DIFF
--- a/Firewall/ContextListener.php
+++ b/Firewall/ContextListener.php
@@ -209,7 +209,7 @@ class ContextListener extends AbstractListener
                 $newToken->setUser($refreshedUser, false);
 
                 // tokens can be deauthenticated if the user has been changed.
-                if ($token instanceof AbstractToken && $this->hasUserChanged($user, $newToken)) {
+                if ($token instanceof AbstractToken && $this->hasUserChanged($refreshedUser, $newToken)) {
                     $userDeauthenticated = true;
 
                     $this->logger?->debug('Cannot refresh token because user has changed.', ['username' => $refreshedUser->getUserIdentifier(), 'provider' => $provider::class]);


### PR DESCRIPTION
Right after we stop the impersonating of a user we get an error.
Oddly, when we refresh the page, the problem goes away. Therefore, the problem definitely lies in the user transition.

> User::getPassword(): Return value must be of type string, null returned

CallStack:
App/Entity/User.php&line=145

```php
    /**
     * @see PasswordAuthenticatedUserInterface
     */
    public function getPassword(): string {
        return $this->password; // <<<
    }
```

vendor/symfony/security-http/Firewall/ContextListener.php -> getPassword (line 299)
vendor/symfony/security-http/Firewall/ContextListener.php :: hasUserChanged (line 211)
vendor/symfony/security-http/Firewall/ContextListener.php -> refreshUser (line 123)
vendor/symfony/security-bundle/Debug/WrappedLazyListener.php -> authenticate (line 46)
vendor/symfony/security-bundle/Security/LazyFirewallContext.php -> authenticate (line 60)
vendor/symfony/security-bundle/Debug/TraceableFirewallListener.php -> __invoke (line 70)
vendor/symfony/security-http/Firewall.php -> callListeners (line 92)
vendor/symfony/event-dispatcher/Debug/WrappedListener.php -> onKernelRequest (line 116)
vendor/symfony/event-dispatcher/EventDispatcher.php -> __invoke (line 206)
vendor/symfony/event-dispatcher/EventDispatcher.php -> callListeners (line 56)
vendor/symfony/event-dispatcher/Debug/TraceableEventDispatcher.php -> dispatch (line 127)
vendor/symfony/http-kernel/HttpKernel.php -> dispatch (line 139)
vendor/symfony/http-kernel/HttpKernel.php -> handleRaw (line 74)
vendor/symfony/http-kernel/Kernel.php -> handle (line 184)
vendor/symfony/runtime/Runner/Symfony/HttpKernelRunner.php -> handle (line 35)
vendor/autoload_runtime.php -> run (line 29)

And after a while I found the problem. In the `Firewall\ContextListener` file, the function `hasUserChanged` gets a cached user entity (`$originalUser` of type `Proxies\__CG__\App\Entity\User`), which sometimes only has properties with `null` values. And as it turned out, the issue occures a little earlier, in `Firewall\ContextListener::refreshUser` the cached user `$user` is passed on to the function, but instead we should pass the just refreshed user entity `$refreshedUser`.
